### PR TITLE
Update education and activity details in cv.html

### DIFF
--- a/pages/cv.html
+++ b/pages/cv.html
@@ -24,8 +24,8 @@
     <div style="margin: 0 0 1em 1em">
         <h3 class="animate">학력</h3>
         <ul>
-            <li class="animate"><a href="https://freshman.kaist.ac.kr/" target="_blank">한국과학기술원 생명과학과(BS) 학사 과정</a><small class="clr-tiny">2026.3 - 현재</small> </li>
-            <li class="animate"><a href="https://freshman.kaist.ac.kr/" target="_blank">한국과학기술원 전산학부(SoC) 학사 과정 복수전공</a><small class="clr-tiny">2026.3 - 현재</small> </li>
+            <li class="animate"><a href="https://freshman.kaist.ac.kr/" target="_blank">한국과학기술원 생명과학과(BS) 학사과정</a><small class="clr-tiny">2026.3 - 현재</small> </li>
+            <li class="animate"><a href="https://freshman.kaist.ac.kr/" target="_blank">한국과학기술원 전산학부(SoC) 학사과정 복수전공</a><small class="clr-tiny">2026.3 - 현재</small> </li>
             <li class="animate"><a href="https://freshman.kaist.ac.kr/" target="_blank">한국과학기술원 새내기과정학부</a><small class="clr-tiny">2025.2 - 2026.2</small> </li>
             <li class="animate"><a href="https://ksa.hs.kr/" target="_blank">한국과학영재학교</a><small class="clr-tiny">2022.2 - 2025.2</small> </li>
         </ul>
@@ -46,6 +46,8 @@
 
             <li class="animate"><a href="https://welfare.kaist.ac.kr/" target="_blank">KAIST 학생복지위원회</a><small class="clr-tiny" style="text-align: right">2025.3 - 현재</small></li>
             <ul>
+                <li class="animate">학생복지위원회 2025 가을학기 홈페이지 TF <small class="clr-tiny">- 추석 귀향 버스 예매 홈페이지 Front-end 및 입금 확인 매크로 개발</small></li>
+                <li class="animate">학생복지위원회 2025 가을학기 문화국원 <small class="clr-tiny">- 학생복지위원회 사업 운영 및 디자인 업무 수행</small></li>
                 <li class="animate">학생복지위원회 2025 봄학기 문화국원 <small class="clr-tiny">- 학생복지위원회 사업 운영 및 디자인 업무 수행</small></li>
             </ul>
             <pre class="spacer-half-em"></pre>
@@ -79,6 +81,7 @@
 
             <li class="animate"><a href="https://talosftc.com/" target="_blank">FTC Team TALOS</a><small class="clr-tiny">2022.5 - 현재</small> </li>
             <ul>
+                <li class="animate">FTC 2025-2026 Programming Part Advisor <small class="clr-tiny">- FIRST AGE</small></li>
                 <li class="animate">FTC 2024-2025 Main Programmer <small class="clr-tiny">- Into The Deep</small></li>
                 <li class="animate">FTC 2023-2024 Team Captain & Main Programmer <small class="clr-tiny">- CENTERSTAGE</small></li>
                 <li class="animate">FTC 2022-2023 Main Programmer <small class="clr-tiny">- PowerPlay</small></li>


### PR DESCRIPTION
Standardized the wording for degree programs in the education section and added new roles and activities under the KAIST 학생복지위원회 and FTC Team TALOS sections.